### PR TITLE
Fix world-age requirement for `@generated` functions in Julia 1.10

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ Tricks = "410a4b4d-49e4-4fbc-ab6d-cb71b17b3775"
 
 [compat]
 ExprTools = "0.1.8"
-Tricks = "0.1.6"
+Tricks = "0.1.8"
 julia = "1.3"
 
 [extras]


### PR DESCRIPTION
Should fix #2. Require https://github.com/oxinabox/Tricks.jl/pull/40