### PR TITLE
Also forward kwargs to the generated switch statement.

### DIFF
--- a/src/ValSplit.jl
+++ b/src/ValSplit.jl
@@ -181,6 +181,21 @@ function _valsplit(def::Dict{Symbol}, idx::Int, val_idxs=[idx])
     # Generate the function body
     if haskey(def, :kwargs)
         # if the default function has kwargs then pass them on as "slurped" kw arguments
+        kwargs = []
+        for kwarg in def[:kwargs]
+            if kwarg.head === :kw
+                arg = kwarg.args[1]
+                if isa(arg,Expr) && arg.head == :(::)
+                    push!(kwargs, Expr(:kw, esc(arg.args[1]), esc(arg.args[1])))
+                elseif isa(arg,Symbol)
+                    push!(kwargs, Expr(:kw, esc(arg), esc(arg)))
+                else
+                    error("Unexpected argument structure $arg")
+                end
+            else # TODO: Support slurped args?
+                error("only named kwargs are supported")
+            end
+        end
         def[:body] = quote
             # Look up the parameters for the Val-typed argument in position idx
             vals = valarg_params($(esc(fname)), $types, $idx, $ptype)
@@ -188,7 +203,7 @@ function _valsplit(def::Dict{Symbol}, idx::Int, val_idxs=[idx])
             function default_f() $(esc(def[:body])) end
             # Generate a switch expression over the Val-type parameters
             return _valswitch(Val(vals), Val($idx), $(esc(fname)), default_f,
-                              $(map(esc, argnames)...); kwargs...)
+                              $(map(esc, argnames)...); $(kwargs...))
         end
     else
         def[:body] = quote

--- a/src/ValSplit.jl
+++ b/src/ValSplit.jl
@@ -192,8 +192,10 @@ function _valsplit(def::Dict{Symbol}, idx::Int, val_idxs=[idx])
                 else
                     error("Unexpected argument structure $arg")
                 end
-            else # TODO: Support slurped args?
-                error("only named kwargs are supported")
+            elseif kwarg.head === :(...)
+                push!(kwargs, Expr(:(...), kwarg.args[1]))
+            else
+                error("Unexpected argument structure $kwarg")
             end
         end
         def[:body] = quote

--- a/src/ValSplit.jl
+++ b/src/ValSplit.jl
@@ -135,13 +135,13 @@ branch conditions. Each branch with value `v` calls `f(args...)`, with
 is called with with no arguments.
 """
 @generated function _valswitch(
-    vals::Val{Vs}, idx::Val{I}, f, default_f, args::Vararg{Any,N}
+    vals::Val{Vs}, idx::Val{I}, f, default_f, args::Vararg{Any,N}; kwargs...
 ) where {Vs, I, N}
     vals = map(QuoteNode, Vs)
     cond_exprs = [Expr(:call, :(==), :(args[$I]), v) for v in vals]
     branch_exprs = map(vals) do v
         args = [i == I ? :(Val($v)) : :(args[$i]) for i in 1:N]
-        return Expr(:call, :f, args...)
+        return Expr(:call, :f, Expr(:parameters, :(kwargs...)), args...)
     end
     default_expr = :(default_f())
     return generate_switch_stmt(cond_exprs, branch_exprs, default_expr)
@@ -177,16 +177,32 @@ function _valsplit(def::Dict{Symbol}, idx::Int, val_idxs=[idx])
     if haskey(def, :whereparams)
         def[:whereparams] = map(esc, def[:whereparams])
     end
+
     # Generate the function body
-    def[:body] = quote
-        # Look up the parameters for the Val-typed argument in position idx
-        vals = valarg_params($(esc(fname)), $types, $idx, $ptype)
-        # Default function returns the original function body
-        function default_f() $(esc(def[:body])) end
-        # Generate a switch expression over the Val-type parameters
-        return _valswitch(Val(vals), Val($idx), $(esc(fname)), default_f,
-                          $(map(esc, argnames)...))
+    if haskey(def, :kwargs)
+        # if the default function has kwargs then pass them on as "slurped" kw arguments
+        def[:body] = quote
+            # Look up the parameters for the Val-typed argument in position idx
+            vals = valarg_params($(esc(fname)), $types, $idx, $ptype)
+            # Default function returns the original function body
+            function default_f() $(esc(def[:body])) end
+            # Generate a switch expression over the Val-type parameters
+            return _valswitch(Val(vals), Val($idx), $(esc(fname)), default_f,
+                              $(map(esc, argnames)...); kwargs...)
+        end
+    else
+        def[:body] = quote
+            # Look up the parameters for the Val-typed argument in position idx
+            vals = valarg_params($(esc(fname)), $types, $idx, $ptype)
+            # Default function returns the original function body
+            function default_f() $(esc(def[:body])) end
+            # Generate a switch expression over the Val-type parameters
+            return _valswitch(Val(vals), Val($idx), $(esc(fname)), default_f,
+                              $(map(esc, argnames)...))
+        end
     end
+
+
     # Return recombined function expression
     return combinedef(def)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -176,10 +176,43 @@ function nameof(animal::Val{:cat}; age=2.0)
     end
 end
 
-
 @test nameof(:dog) == "Dog"
 @test nameof(:cat) == "Cat"
 @test nameof(:dog; age=1.0) == "Puppy"
 @test nameof(:cat; age=1.0) == "Kitten"
-@test_throws ErrorException nameof(:dragon, age=100.0) == "Elder Dragon"
+@test_throws ErrorException nameof(:dragon; age=100.0) == "Elder Dragon"
 @test_throws ErrorException nameof(:dragon) == "Dragon"
+
+
+@valsplit function groupnameof(Val(animal::Symbol); count::Integer=1, kwargs...)
+    error("groupnameof not defined for $animal")
+end
+
+function groupnameof(animal::Val{:antelope}; count::Integer=1)
+    if count == 1
+        return "Antelope"
+    else
+        return "Herd of Antelope"
+    end
+end
+
+function groupnameof(animal::Val{:finch}; count::Integer=1, age::Number=1.0)
+    if count == 1
+        return "Finch"
+    else
+        if age > 0.0
+            return "Flock of Finches"
+        else
+            return "Clutch of Finch eggs"
+        end
+    end
+end
+
+@test groupnameof(:antelope) == "Antelope"
+@test groupnameof(:antelope; count=10) == "Herd of Antelope"
+@test groupnameof(:finch; count=10, age=1.0) == "Flock of Finches"
+@test groupnameof(:finch; count=10, age=-1.0) == "Clutch of Finch eggs"
+@test_throws MethodError groupnameof(:antelope; count=10, age=1.0) == "Herd of Antelope" # will throw method error if not defined with slurped kwargs.
+@test_throws ErrorException groupnameof(:dragon; age=100.0) == "Elder Dragon"
+@test_throws ErrorException groupnameof(:dragon; count=100, age=100.0) == "Flight of Elder Dragons"
+@test_throws ErrorException groupnameof(:dragon; count=2, age=-10.0) == "Clutch of Dragon eggs"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -154,3 +154,32 @@ Animals.soundof(animal::Val{:human}) = "meh"
 @test valarg_has_param(π, spelling, 1, Irrational)
 @test valarg_has_param(:japanese, soundof, Tuple{Val{:cat}, Any}, 2)
 @test valarg_has_param((:frog, :english), soundof, Tuple{Any, Any}, (1, 2))
+
+
+@valsplit function nameof(Val(animal::Symbol); age::Number=10.0)
+    error("nameof undefined for animal: $animal")
+end
+
+function nameof(animal::Val{:dog}; age::Number=5.0)
+    if age > 2.0
+        return "Dog"
+    else
+        return "Puppy"
+    end
+end
+
+function nameof(animal::Val{:cat}; age=2.0)
+    if age > 1.0
+        return "Cat"
+    else
+        return "Kitten"
+    end
+end
+
+
+@test nameof(:dog) == "Dog"
+@test nameof(:cat) == "Cat"
+@test nameof(:dog; age=1.0) == "Puppy"
+@test nameof(:cat; age=1.0) == "Kitten"
+@test_throws ErrorException nameof(:dragon, age=100.0) == "Elder Dragon"
+@test_throws ErrorException nameof(:dragon) == "Dragon"


### PR DESCRIPTION
I ran into the same limitation as #4 when trying to use this package to typestable-ly convert strings to `@kwdef` types  in an AOT compiled binary. I believe that this solves that issue and you can now forward kwargs through to the generated switch statement. From my testing it seems to not negatively affect the type-stability of the resulting code.